### PR TITLE
Error message

### DIFF
--- a/P3/src/main/java/com/revature/P3/controllers/AuthController.java
+++ b/P3/src/main/java/com/revature/P3/controllers/AuthController.java
@@ -26,7 +26,7 @@ public class AuthController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public Principal login(@RequestBody(required = false) NewLoginRequest req) {
         if (req == null) {
-            throw new InvalidAuthException();
+            throw new InvalidAuthException("Not Authorized");
         }
 
         Principal principal = null;
@@ -44,10 +44,10 @@ public class AuthController {
                 );
             }
             else {
-                throw new InvalidAuthException();
+                throw new InvalidAuthException("Not Authorized");
             }
         } catch (Exception exception) {
-            throw new InvalidAuthException();
+            throw new InvalidAuthException("Not Authorized");
         }
 
         String token = tokenService.createNewToken(principal);
@@ -57,7 +57,7 @@ public class AuthController {
 
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ExceptionHandler(InvalidAuthException.class)
-    public InvalidAuthException handleInvalidAuthException (InvalidAuthException exception) {
-        return exception;
+    public String handleInvalidAuthException (InvalidAuthException exception) {
+        return exception.getMessage();
     }
 }

--- a/P3/src/main/java/com/revature/P3/controllers/ClaimController.java
+++ b/P3/src/main/java/com/revature/P3/controllers/ClaimController.java
@@ -27,26 +27,26 @@ public class ClaimController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public List<Claim> viewAllClaims(HttpServletRequest req) {
         String token = req.getHeader("authorization");
-        if (token == null || token.isEmpty()) throw new InvalidAuthException();
+        if (token == null || token.isEmpty()) throw new InvalidAuthException("Not Authorized");
 
         Principal principal = tokenService.retrievePrincipalFromToken(token);
         String role = principal.getRole();
 
-        if (!role.equals(Roles.Insurer.toString())) throw new InvalidAuthException();
+        if (!role.equals(Roles.Insurer.toString())) throw new InvalidAuthException("Not Authorized");
 
-        throw new InvalidAuthException();
+        throw new InvalidAuthException("Not Authorized");
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public void createClaim(@RequestBody(required = false) NewClaimRequest claimReq, HttpServletRequest servletReq) {
         String token = servletReq.getHeader("authorization");
-        if (token == null || token.isEmpty()) throw new InvalidAuthException();
+        if (token == null || token.isEmpty()) throw new InvalidAuthException("Not Authorized");
 
         Principal principal = tokenService.retrievePrincipalFromToken(token);
         String role = principal.getRole();
 
-        if (!role.equals(Roles.Patient.toString())) throw new InvalidAuthException();
+        if (!role.equals(Roles.Patient.toString())) throw new InvalidAuthException("NOt Authorized");
 
         throw new InvalidClaimException();
     }
@@ -55,14 +55,14 @@ public class ClaimController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public void approveClaim(@PathVariable(name="claimId") String claimId, HttpServletRequest req) {
         String token = req.getHeader("authorization");
-        if (token == null || token.isEmpty()) throw new InvalidAuthException();
+        if (token == null || token.isEmpty()) throw new InvalidAuthException("Not Authorized");
 
         Principal principal = tokenService.retrievePrincipalFromToken(token);
         String role = principal.getRole();
 
-        if (!role.equals(Roles.Insurer.toString())) throw new InvalidAuthException();
+        if (!role.equals(Roles.Insurer.toString())) throw new InvalidAuthException("Not Authorized");
 
-        throw new InvalidAuthException();
+        throw new InvalidAuthException("Not Authorized");
     }
 
     @ResponseStatus(HttpStatus.UNAUTHORIZED)

--- a/P3/src/main/java/com/revature/P3/controllers/ClaimController.java
+++ b/P3/src/main/java/com/revature/P3/controllers/ClaimController.java
@@ -46,7 +46,7 @@ public class ClaimController {
         Principal principal = tokenService.retrievePrincipalFromToken(token);
         String role = principal.getRole();
 
-        if (!role.equals(Roles.Patient.toString())) throw new InvalidAuthException("NOt Authorized");
+        if (!role.equals(Roles.Patient.toString())) throw new InvalidAuthException("Not Authorized");
 
         throw new InvalidClaimException();
     }

--- a/P3/src/main/java/com/revature/P3/controllers/UserController.java
+++ b/P3/src/main/java/com/revature/P3/controllers/UserController.java
@@ -43,12 +43,12 @@ public class UserController {
     @ResponseStatus(HttpStatus.CREATED)
     public void createNurse(@RequestBody(required = false) NewUserRequest req, HttpServletRequest servletReq) {
         String token = servletReq.getHeader("authorization");
-        if (token == null || token.isEmpty()) throw new InvalidAuthException();
+        if (token == null || token.isEmpty()) throw new InvalidAuthException("Not Authorized");
 
         Principal principal = tokenService.retrievePrincipalFromToken(token);
         String role = principal.getRole();
 
-        if (!role.equals(Roles.Admin.toString())) throw new InvalidAuthException();
+        if (!role.equals(Roles.Admin.toString())) throw new InvalidAuthException("Not Authorized");
 
         try {
             req.setPassword(HashService.getHash(req.getPassword()));
@@ -63,12 +63,12 @@ public class UserController {
     @ResponseStatus(HttpStatus.CREATED)
     public void createDoctor(@RequestBody(required = false) NewUserRequest req, HttpServletRequest servletReq) {
         String token = servletReq.getHeader("authorization");
-        if (token == null || token.isEmpty()) throw new InvalidAuthException();
+        if (token == null || token.isEmpty()) throw new InvalidAuthException("Not Authorized");
 
         Principal principal = tokenService.retrievePrincipalFromToken(token);
         String role = principal.getRole();
 
-        if (!role.equals(Roles.Admin.toString())) throw new InvalidAuthException();
+        if (!role.equals(Roles.Admin.toString())) throw new InvalidAuthException("Not Authorized");
 
         try {
             req.setPassword(HashService.getHash(req.getPassword()));
@@ -83,12 +83,12 @@ public class UserController {
     @ResponseStatus(HttpStatus.CREATED)
     public void createInsurer(@RequestBody(required = false) NewUserRequest req, HttpServletRequest servletReq) {
         String token = servletReq.getHeader("authorization");
-        if (token == null || token.isEmpty()) throw new InvalidAuthException();
+        if (token == null || token.isEmpty()) throw new InvalidAuthException("Not Authorized");
 
         Principal principal = tokenService.retrievePrincipalFromToken(token);
         String role = principal.getRole();
 
-        if (!role.equals(Roles.Admin.toString())) throw new InvalidAuthException();
+        if (!role.equals(Roles.Admin.toString())) throw new InvalidAuthException("Not Authorized");
 
         try {
             req.setPassword(HashService.getHash(req.getPassword()));
@@ -103,42 +103,42 @@ public class UserController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     public List<User> viewAllUsers(HttpServletRequest req) {
         String token = req.getHeader("authorization");
-        if (token == null || token.isEmpty()) throw new InvalidAuthException();
+        if (token == null || token.isEmpty()) throw new InvalidAuthException("Not Authorized");
 
         Principal principal = tokenService.retrievePrincipalFromToken(token);
         String role = principal.getRole();
 
-        if (!role.equals(Roles.Admin.toString())) throw new InvalidAuthException();
+        if (!role.equals(Roles.Admin.toString())) throw new InvalidAuthException("Not Authorized");
 
-        throw new InvalidAuthException();
+        throw new InvalidAuthException("Not Authorized");
     }
 
     @PutMapping(path="activate/{userId}")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public void activateUser(@PathVariable(name="userId") String userId, HttpServletRequest req) {
         String token = req.getHeader("authorization");
-        if (token == null || token.isEmpty()) throw new InvalidAuthException();
+        if (token == null || token.isEmpty()) throw new InvalidAuthException("Not Authorized");
 
         Principal principal = tokenService.retrievePrincipalFromToken(token);
         String role = principal.getRole();
 
-        if (!role.equals(Roles.Admin.toString())) throw new InvalidAuthException();
+        if (!role.equals(Roles.Admin.toString())) throw new InvalidAuthException("Not Authorized");
 
-        throw new InvalidAuthException();
+        throw new InvalidAuthException("Not Authorized");
     }
 
     @PutMapping(path="deactivate/{userId}")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public void deactivateUser(@PathVariable(name="userId") String userId, HttpServletRequest req) {
         String token = req.getHeader("authorization");
-        if (token == null || token.isEmpty()) throw new InvalidAuthException();
+        if (token == null || token.isEmpty()) throw new InvalidAuthException("Not Authorized");
 
         Principal principal = tokenService.retrievePrincipalFromToken(token);
         String role = principal.getRole();
 
-        if (!role.equals(Roles.Admin.toString())) throw new InvalidAuthException();
+        if (!role.equals(Roles.Admin.toString())) throw new InvalidAuthException("Not Authorized");
 
-        throw new InvalidAuthException();
+        throw new InvalidAuthException("Not Authorized");
     }
 
     @ResponseStatus(HttpStatus.FORBIDDEN)

--- a/P3/src/main/java/com/revature/P3/services/TokenService.java
+++ b/P3/src/main/java/com/revature/P3/services/TokenService.java
@@ -46,7 +46,7 @@ public class TokenService {
                     .parseClaimsJws(token)
                     .getBody();
         } catch (Exception e) {
-            throw new InvalidAuthException();
+            throw new InvalidAuthException("Not Authorized");
         }
 
         Principal principal = new Principal(

--- a/P3/src/main/java/com/revature/P3/services/UserService.java
+++ b/P3/src/main/java/com/revature/P3/services/UserService.java
@@ -26,7 +26,7 @@ public class UserService {
         try {
             candidate = this.userRepository.findAllByUsername(req.getUsername());
         } catch (Exception e) {
-            throw new InvalidAuthException();
+            throw new InvalidAuthException("Not Authorized");
         }
 
         return candidate;

--- a/P3/src/main/java/com/revature/P3/utils/custom_exceptions/InvalidAuthException.java
+++ b/P3/src/main/java/com/revature/P3/utils/custom_exceptions/InvalidAuthException.java
@@ -1,4 +1,7 @@
 package com.revature.P3.utils.custom_exceptions;
 
 public class InvalidAuthException extends RuntimeException {
+    public InvalidAuthException(String message) {
+        super(message);
+    }
 }

--- a/P3/src/test/java/com/revature/P3/services/UserServiceTest.java
+++ b/P3/src/test/java/com/revature/P3/services/UserServiceTest.java
@@ -56,6 +56,7 @@ public class UserServiceTest {
         }
         catch (InvalidAuthException exception) {
             test = true;
+            assertTrue(exception.getMessage().equals("Not Authorized"));
         }
 
         assertTrue(test);


### PR DESCRIPTION
Instead of returning an error trace, return a readable message instead for Auth-related activities. Set an example for how errors should be handled to make it easier for the frontend.